### PR TITLE
fix: don't pass empty string for CA in CH connection settings

### DIFF
--- a/charts/housewatch/Chart.yaml
+++ b/charts/housewatch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: housewatch
 description: Open source tool for monitoring and managing ClickHouse clusters
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "0.1.1"
 dependencies:
   - name: postgresql

--- a/housewatch/settings/__init__.py
+++ b/housewatch/settings/__init__.py
@@ -247,10 +247,10 @@ POSTHOG_PROJECT_API_KEY = get_from_env("POSTHOG_PROJECT_API_KEY", "123456789")
 # ClickHouse
 
 CLICKHOUSE_HOST = get_from_env("CLICKHOUSE_HOST", "localhost")
-CLICKHOUSE_VERIFY = str_to_bool(get_from_env("CLICKHOUSE_VERIFY", "True"))
-CLICKHOUSE_CA = get_from_env("CLICKHOUSE_CA", "")
-CLICKHOUSE_SECURE = str_to_bool(get_from_env("CLICKHOUSE_SECURE", "True"))
-CLICKHOUSE_DATABASE = get_from_env("CLICKHOUSE_DATABASE", "defaul")
+CLICKHOUSE_VERIFY = str_to_bool(get_from_env("CLICKHOUSE_VERIFY", True))
+CLICKHOUSE_CA = get_from_env("CLICKHOUSE_CA")
+CLICKHOUSE_SECURE = str_to_bool(get_from_env("CLICKHOUSE_SECURE", True))
+CLICKHOUSE_DATABASE = get_from_env("CLICKHOUSE_DATABASE", "default")
 CLICKHOUSE_USER = get_from_env("CLICKHOUSE_USER", "default")
 CLICKHOUSE_PASSWORD = get_from_env("CLICKHOUSE_PASSWORD", "")
 


### PR DESCRIPTION
- fix: don't pass empty string for CA in CH connection settings
- bump chart version
