### PR TITLE
chore: add healthz and admin to the nginx configmap for access

### DIFF
--- a/charts/housewatch/templates/nginx-configmap.yaml
+++ b/charts/housewatch/templates/nginx-configmap.yaml
@@ -29,5 +29,21 @@ data:
             proxy_set_header Connection 'upgrade';
             proxy_set_header Host $host;
         }
+
+        location /admin {
+            proxy_pass http://housewatch-api:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+        }
+
+        location /healthz {
+            proxy_pass http://housewatch-api:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+        }
       }
     }


### PR DESCRIPTION
Note: We'll need to deploy the chart and not just bump the image sha this time.