### PR TITLE
Default to '/' for frontend app location (thanks nginx)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ housewatch.sqlite3
 yarn.lock
 
 charts/housewatch/charts/
+.pnpm/

--- a/charts/housewatch/Chart.yaml
+++ b/charts/housewatch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: housewatch
 description: Open source tool for monitoring and managing ClickHouse clusters
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "0.1.2"
 dependencies:
   - name: postgresql

--- a/charts/housewatch/templates/nginx-configmap.yaml
+++ b/charts/housewatch/templates/nginx-configmap.yaml
@@ -31,7 +31,7 @@ data:
         }
 
         location /admin {
-            proxy_pass http://housewatch-api:8000;
+            proxy_pass http://{{ include "housewatch.fullname" . }}-api:8000;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';
@@ -39,7 +39,7 @@ data:
         }
 
         location /healthz {
-            proxy_pass http://housewatch-api:8000;
+            proxy_pass http://{{ include "housewatch.fullname" . }}-api:8000;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,6 @@
-FROM node:lts-alpine3.20
+FROM alpine:latest
 
 WORKDIR /frontend
-
-RUN pnpm i && vite build
 
 COPY build/ build/
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,8 @@
-FROM alpine:latest
+FROM node:lts-alpine3.20
 
 WORKDIR /frontend
+
+RUN pnpm i && vite build
 
 COPY build/ build/
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
             },
         },
     },
-    base: process.env.NODE_ENV === "production" ? "/webapp/" : "/",
+    base: "/",
     build: {
         outDir: "./build"
     }


### PR DESCRIPTION
We copy the frontend assets to nginx at deploy time. This means we don't need to preface everything with `/webapp`

