### PR TITLE
chore: update docker stack to run HouseWatch locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following are the supported environment variables for configuring your House
 To run HouseWatch locally along with a local ClickHouse instance, execute: 
 
 ```bash
-docker compose -f docker-compose.dev.yml up
+docker compose -f docker-compose.dev.yml up -d
 ```
 
 then go to http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ The following are the supported environment variables for configuring your House
 
 </details>
 
+## 🏡 Running locally
+
+To run HouseWatch locally along with a local ClickHouse instance, execute: 
+
+```bash
+docker compose -f docker-compose.dev.yml up
+```
+
+then go to http://localhost:8080
+
 ## 💡 Motivation
 
 At PostHog we manage a few large ClickHouse clusters and found ourselves in need of a tool to monitor and manage these more easily.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       CLICKHOUSE_DATABASE: default
       CLICKHOUSE_USER: default
       CLICKHOUSE_PASSWORD: ""
-      CLICKHOUSE_CLUSTER: parallel_replicas
+      CLICKHOUSE_CLUSTER: housewatch
       CLICKHOUSE_SECURE: false
       CLICKHOUSE_VERIFY: false
       CLICKHOUSE_CA: ""
@@ -34,6 +34,25 @@ services:
       - db
       - redis
       - rabbitmq
+
+  web:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+
+  caddy:
+    image: caddy:2.6.1
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+      - "443:443"
+    environment:
+      SITE_ADDRESS: ":8080"
+    volumes:
+      - ./docker/Caddyfile:/etc/caddy/Caddyfile
+    depends_on:
+      - web
+      - app
 
   db:
     image: postgres:14-alpine
@@ -68,12 +87,14 @@ services:
       - rabbitmq
 
   clickhouse:
-    image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:23.4.2.11}
+    image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:23.12.5}
     restart: on-failure
     depends_on:
       - zookeeper
     volumes:
       - ./docker/clickhouse-server/config.d:/etc/clickhouse-server/config.d
+    ports:
+      - "8123:8123"
 
   zookeeper:
     image: zookeeper:3.7.0

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -66,6 +66,8 @@ services:
       test: ["CMD-SHELL", "pg_isready -U housewatch"]
       interval: 5s
       timeout: 5s
+    ports:
+      - "5432:5432"
 
   redis:
     image: redis:6.2.7-alpine

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,14 @@
+FROM node:20.4.0-alpine
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+RUN corepack enable
+
+WORKDIR /frontend
+
+COPY . .
+
+RUN pnpm i
+
+CMD ["pnpm", "vite", "--port", "3000"]

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -11,4 +11,4 @@ COPY . .
 
 RUN pnpm i
 
-CMD ["pnpm", "vite", "--port", "3000"]
+CMD ["pnpm", "vite", "--port", "3000", "--host"]


### PR DESCRIPTION
This will fix the docker-compose dev file so we can easily start HouseWatch with all its needed components.