### PR TITLE
fix: cached query_settings

### DIFF
--- a/housewatch/clickhouse/backups.py
+++ b/housewatch/clickhouse/backups.py
@@ -28,6 +28,7 @@ def execute_backup(
     base_backup: Optional[str] = None,
     is_sharded: bool = False,
 ):
+    query_settings = {}
     """
     This function will execute a backup on each shard in a cluster
     This is very similar to run_query_on_shards but it has very specific params


### PR DESCRIPTION
For some reason (I lack knowledge of celery / Django, there must be an explanation for this), the `query_settings` were being cached.

This meant that, when a base backup was executed after an incremental backup, the base backup was taking the last `query_settings` used, so when the base backup was performed it was using the previous base backup cached in the query settings from the last execution. It could even be a base backup for a different table. 

The base backup should never use a previous base backup.

This fixes the issue, but I'll keep monitoring it for the next following backups performed.

![image](https://github.com/PostHog/HouseWatch/assets/7421248/6a00ad46-ea8b-4d26-b639-c1cacc6576cb)


