### PR TITLE
fix: check for table not null or empty for is_database_backup

### DIFF
--- a/housewatch/models/backup.py
+++ b/housewatch/models/backup.py
@@ -47,7 +47,7 @@ class ScheduledBackup(models.Model):
         return self.schedule.split(" ")[3]
 
     def is_database_backup(self):
-        return self.table is None
+        return not self.table
 
     def is_table_backup(self):
         return self.table is not None


### PR DESCRIPTION
For empty strings in tables it was not being taken as a database backup.

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMjYyNndwbmVsdTBxOHE5Mmt2aWViOHZhbTk2M2RseTQwb2hlNTkyYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/VJBd91kUU5FJtcDUvL/giphy.gif)