### PR TITLE
Remove image pull secret

### DIFF
--- a/charts/housewatch/values.yaml
+++ b/charts/housewatch/values.yaml
@@ -16,9 +16,6 @@ clickhouse:
   verify: "false"
   ca: ""
 
-imagePullSecrets:
-  - name: dockerconfigjson-ghcr-io
-
 service:
   annotations: {}
 


### PR DESCRIPTION
This image is public and shouldn't require a secret. We'd also like to delete this secret from our cluster, since it's a classic PAT.