### PR TITLE
fix: ClickHouse compatibility and database scoping bugs

### DIFF
--- a/housewatch/api/analyze.py
+++ b/housewatch/api/analyze.py
@@ -24,7 +24,7 @@ from housewatch.clickhouse.queries.sql import (
     LOGS_FREQUENCY_SQL,
     EXPLAIN_QUERY,
     BENCHMARKING_SQL,
-    AVAILABLE_TABLES_SQL,
+    TABLES_SQL,
     TABLE_SCHEMAS_SQL,
 )
 from uuid import uuid4
@@ -263,7 +263,7 @@ class AnalyzeViewset(GenericViewSet):
 
     @action(detail=False, methods=["GET"])
     def tables(self, request: Request):
-        query_result = run_query(AVAILABLE_TABLES_SQL, use_cache=False)
+        query_result = run_query(TABLES_SQL, use_cache=False)
         return Response(query_result)
 
     @action(detail=False, methods=["POST"])


### PR DESCRIPTION
## Summary

Fixes several bugs that break HouseWatch on single-node setups and newer ClickHouse versions:

- **Logs 500 error (fixes #53)**: `TEXT_LOG_SYSTEM_TABLE` fallback used `"system.text"` instead of `"system.text_log"` — the table doesn't exist, causing 500 on `/api/analyze/logs` and `/api/analyze/logs_frequency`
- **Schema page stuck loading**: The `tables` endpoint used `AVAILABLE_TABLES_SQL` (returns `{database, table}`) but the schema page frontend expects `{name, total_bytes, ...}` from `TABLES_SQL`. Switched the endpoint to use `TABLES_SQL`
- **Database scoping**: `TABLES_SQL`, `SCHEMA_SQL`, and `PARTS_SQL` had no `WHERE database = ...` filter, returning results from all databases. Now scoped to `CLICKHOUSE_DATABASE`
- **Disk usage stuck loading**: `NODE_STORAGE_SQL` filtered on `type = 'local'` but newer ClickHouse versions (tested on 26.1.2) use `'Local'` (capitalized). Changed to `lower(type) = 'local'`

## Test plan

- [x] `/api/analyze/logs` returns log entries instead of 500
- [x] `/api/analyze/logs_frequency` returns frequency data instead of 500
- [x] `/schema` page loads table list with sizes and row counts
- [x] `/schema/{table}` shows column details scoped to configured database
- [x] Disk usage page shows node storage info
- [x] Tested on ClickHouse 26.1.2, single-node, non-cluster setup